### PR TITLE
New-ServiceFabricNuGetPackage: fixed function killing console

### DIFF
--- a/PowerShell/SFNuGetModule.psm1
+++ b/PowerShell/SFNuGetModule.psm1
@@ -25,22 +25,18 @@ function New-ServiceFabricNuGetPackage {
             Revision History:
                 10/09/2017 : Haishi Bai - Created.
     #>
+    [cmdletbinding()]
     param(
-        [string] $InputPath,
-        [string] $OutPath,
-        [switch] $Publish=$false
+        [parameter(mandatory=$true)][string] $InputPath,
+        [parameter(mandatory=$true)][string] $OutPath,
+        [parameter(mandatory=$false)][switch] $Publish=$false
     )
+
+    $ErrorActionPreference = "stop"
     
     #chek if InputPath exists
-    if (!$InputPath -Or !(Test-Path $InputPath)) {
-        Write-Host "Input path is null or not found."
-        Exit 1
-    }
-    
-    #check if OutPath parameter is null
-    if (!$OutPath) {
-        Write-Host "Output path is null."
-        Exit 1
+    if (!(Test-Path $InputPath)) {
+        Write-error "Input path is not found."
     }
 
     #create output folder if doesn't exists


### PR DESCRIPTION
This should fix the current behaviour of the function 'New-ServiceFabricNuGetPackage' to kill the console. To force parameters having values i have updated the parameter-declaration so there is no need to check for $null and throw errors, powershell does that for you.
I have set the $ErrorActionPreference to Stop so when-ever i first write onto the error-stream the function will stop. In case the InputPath does not exist i write a message saying this to the error-stream and the function will stop. This 'exits' the function without killing consoles trying to call this.

This should solve issue #2 