### PR TITLE
Fixes paths to NuGet, tools

### DIFF
--- a/PowerShell/SFNuGetModule.psm1
+++ b/PowerShell/SFNuGetModule.psm1
@@ -49,9 +49,9 @@ function New-ServiceFabricNuGetPackage {
 
     #copy files
     Robocopy $InputPath $WorkingFolder /S /NS /NC /NFL /NDL /NP /NJH /NJS    
-    Robocopy .\tools $WorkingFolder\tools /S /NS /NC /NFL /NDL /NP /NJH /NJS
-    Copy-Item .\NuGet.exe $WorkingFolder
-    Copy-Item .\NuGet.config $WorkingFolder
+    Robocopy "$(Get-ScriptDirectory)\tools" $WorkingFolder\tools /S /NS /NC /NFL /NDL /NP /NJH /NJS
+    Copy-Item "$(Get-ScriptDirectory)\NuGet.exe" $WorkingFolder
+    Copy-Item "$(Get-ScriptDirectory)\NuGet.config" $WorkingFolder
     
     if (Test-AppPackagePath $InputPath) {
         #This is an application package folder, package all services under the folder
@@ -387,7 +387,7 @@ function New-ServicePackage {
     )
 
     #make nuget.exe writable
-    Set-ItemProperty NuGet.exe -Name IsReadOnly -Value $false
+    Set-ItemProperty "$workingPath\NuGet.exe" -Name IsReadOnly -Value $false
 
     #create nupkg file backup
     if (Test-Path *.nupkg) {


### PR DESCRIPTION
I ran into issues executing `New-ServiceFabricNuGetPackage` outside of the `PowerShell` folder. These changes fixes those issues.
* Uses script directory for locating NuGet, tools folder for copying
* Uses working folder for locating copy of NuGet